### PR TITLE
Fixes "Invalid calling object" on IE11

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -19,6 +19,7 @@ import {
 } from './constants';
 
 const charCodeAt = String.prototype.charCodeAt;
+const toString = Object.prototype.toString;
 const keys = Object.keys;
 
 /**


### PR DESCRIPTION
The [global `toString` method](https://github.com/planttheidea/hash-it/blob/0930de48b44cd6a99835cd07b8a6cf0461a6282d/src/utils.js#L352) in IE does not allow it to be called on
objects other than `window`. It will throw an "Invalid calling object"
error when this happens.

This PR ensures that the `Object.prototype.toString` is used instead
which allows any value to be converted to a string.