### PR TITLE
chore: update npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,9 @@ test
 webpack
 *.csv
 yarn*
+__tests__
+results_*.txt
+jest.config.js
+jest.init.js
+webpack.config.js
+tsconfig.json


### PR DESCRIPTION
The existing published npm package size is very large. This pull request reduces the upacked size from **3.6MB** to **187kB**.

Before change: 
```
npm notice 
npm notice 📦  hash-it@5.0.0
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE                         
npm notice 16.5kB dist/hash-it.cjs.js             
npm notice 16.4kB dist/hash-it.esm.js             
npm notice 17.6kB dist/hash-it.js                 
npm notice 5.7kB  dist/hash-it.min.js             
npm notice 417B   jest.config.js                  
npm notice 40B    jest.init.js                    
npm notice 1.6kB  webpack.config.js               
npm notice 2.6kB  package.json                    
npm notice 404B   tsconfig.json                   
npm notice 3.4MB  __tests__/__helpers__/words.json
npm notice 31.0kB dist/hash-it.cjs.js.map         
npm notice 31.0kB dist/hash-it.esm.js.map         
npm notice 31.0kB dist/hash-it.js.map             
npm notice 23.7kB dist/hash-it.min.js.map         
npm notice 4.9kB  CHANGELOG.md                    
npm notice 6.0kB  README.md                       
npm notice 1.3kB  __tests__/arrayBuffer.ts        
npm notice 188B   __tests__/hash.ts               
npm notice 376B   index.d.ts                      
npm notice 6.6kB  __tests__/index.ts              
npm notice 9.4kB  __tests__/__helpers__/values.ts 
npm notice 2.6kB  results_2.1.2.txt               
npm notice 2.7kB  results_3.0.0.txt               
npm notice 2.7kB  results_4.1.0.txt               
npm notice 2.7kB  results_latest.txt              
npm notice === Tarball Details === 
npm notice name:          hash-it                                 
npm notice version:       5.0.0                                   
npm notice filename:      hash-it-5.0.0.tgz                       
npm notice package size:  765.8 kB                                
npm notice unpacked size: 3.6 MB                                  
npm notice shasum:        a3ae9be7d4c2d55f95f3178f37dd0ae195cfe3fa
npm notice integrity:     sha512-S2f3QJxQ6l4nE[...]mMObULM7CAGRw==
npm notice total files:   26                                      
npm notice 
hash-it-5.0.0.tgz
```

After change:
```
npm notice 
npm notice 📦  hash-it@5.0.0
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE                
npm notice 16.5kB dist/hash-it.cjs.js    
npm notice 16.4kB dist/hash-it.esm.js    
npm notice 17.6kB dist/hash-it.js        
npm notice 5.7kB  dist/hash-it.min.js    
npm notice 2.6kB  package.json           
npm notice 31.0kB dist/hash-it.cjs.js.map
npm notice 31.0kB dist/hash-it.esm.js.map
npm notice 31.0kB dist/hash-it.js.map    
npm notice 23.7kB dist/hash-it.min.js.map
npm notice 4.9kB  CHANGELOG.md           
npm notice 6.0kB  README.md              
npm notice 376B   index.d.ts             
npm notice === Tarball Details === 
npm notice name:          hash-it                                 
npm notice version:       5.0.0                                   
npm notice filename:      hash-it-5.0.0.tgz                       
npm notice package size:  25.6 kB                                 
npm notice unpacked size: 187.8 kB                                
npm notice shasum:        d30b4ca8d4e0e4fd9adb2b206ed0232b52623d05
npm notice integrity:     sha512-ipdckM+u/pxwv[...]/rySyV3/Chxmg==
npm notice total files:   13                                      
npm notice 
```